### PR TITLE
add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+**Description**
+
+Describe what this pull request changes, and why. If there is a big design decision involved, put it in the
+codebase (docstring/README/ADR) and link to it here.
+
+**tickets and issues**: If there is a related publicly viewable JIRA ticket or GitHub issue, link to it here. If the
+ticket is not publicly viewable, take care to repeat any necessary information in the description. If there is no
+ticket, omit this.
+
+**Discussions**: Link to any public discussions on discuss.openedx.org or elsewhere. Otherwise omit this.
+
+**Dependencies**: None
+
+**Screenshots**: Always include screenshots if there is any change to the UI (ideally, both "before" and "after"
+screenshots, if applicable). If there are no UI changes, omit this.
+
+**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.
+
+**Testing instructions**:
+
+1. Step by step manual setup/testing/verification instructions for your reviewers go here. Make sure you (the author)
+have already manually tested it using the same steps.
+2. Be sure to include any necessary configuration steps, like setting feature flags
+3. Step 3
+
+**Author notes and concerns**:
+
+1. List any concerns, known bugs, or open questions.
+2. 🚩 Are there any database migrations? See
+[Everything About (edx) Migrations](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations)
+3. If there are none, omit this section


### PR DESCRIPTION
**Description**

This PR adds a pull request template in Github. The contents of the template will be used as the default content of a pull request description, and PR authors will edit it before submitting a pull request. 

**tickets and issues**: 

https://github.com/edx/open-edx-proposals/issues/171

**Screenshots**: TBD

**Merge deadline**: "None" 

**Testing instructions**:

As far as I know, the only way I know to test PR templates is to merge them and create a PR

1. If you don't already have a suitable fork, fork edx-platform 
2. Merge this commit into master on your fork
3. Open a PR _on your fork_ 
4. The PR description should be pre-populated with the contents of `pull_request_template.md`

**Author notes and concerns**:

1. This PR does not address any standards for annotations, or commit messages 